### PR TITLE
Add Nathan Dautenhahn and link to site

### DIFF
--- a/index.md
+++ b/index.md
@@ -104,6 +104,8 @@ Matthew	Milano, University of California, Berkeley
 
 Natacha	Crooks, UC Berkeley
 
+[Nathan Dautenhahn, Rice University](nathandautenhahn.com)
+
 Naveen Kr. Sharma, Google
 
 Niel Lebeck, Google


### PR DESCRIPTION
Signed-off-by: Nathan Dautenhahn <ndd@rice.edu>